### PR TITLE
Make mini-post descriptions scrollable

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -60,6 +60,7 @@ audio{
     padding-left: 2%;
     height: 350px;
     border-left:2px solid #ddd;
+    overflow: auto;
 
     aside{
       border-bottom:2px solid #ddd;


### PR DESCRIPTION
Before:
![rubyindia podcastbefore](https://cloud.githubusercontent.com/assets/3154126/12908050/b3c915d0-cf18-11e5-84fc-cd3f54ea5bb1.png)

After:
![rubyindia podcast](https://cloud.githubusercontent.com/assets/3154126/12908053/c1fc4b68-cf18-11e5-9539-d8b7dd56430c.png)
